### PR TITLE
Bring config form to front when it's opened before.

### DIFF
--- a/shadowsocks-csharp/View/MenuViewController.cs
+++ b/shadowsocks-csharp/View/MenuViewController.cs
@@ -231,7 +231,7 @@ namespace Shadowsocks.View
         {
             if (configForm != null)
             {
-                configForm.Focus();
+                configForm.Activate();
             }
             else
             {


### PR DESCRIPTION
"configForm.Focus()" can't bring the form to front  when the form have been opened and back of some other windows. The solution is use "configForm.Activate()".
