### PR TITLE
Added support for assigning folder where ss_polipo.exe and polipo.conf are extracted

### DIFF
--- a/shadowsocks-csharp/Controller/PolipoRunner.cs
+++ b/shadowsocks-csharp/Controller/PolipoRunner.cs
@@ -19,8 +19,33 @@ namespace Shadowsocks.Controller
 
         static PolipoRunner()
         {
-            // temppath = Path.GetTempPath();
-            temppath = Environment.CurrentDirectory;
+            temppath = Path.GetTempPath();
+            string[] commandLineArgs = Environment.GetCommandLineArgs();
+            for (int i = 0; i < commandLineArgs.Length; i++)
+            {
+                string commandLineArg = commandLineArgs[i];
+                if (commandLineArg.ToLower() == "/SameFolderForPolipo".ToLower())
+                {
+                    temppath = Environment.CurrentDirectory;
+                }
+                if (commandLineArg.ToLower() == "/PolipoFolder".ToLower())
+                {
+                    if (i == commandLineArgs.Length - 1)
+                    {
+                        System.Windows.Forms.MessageBox.Show("Polipo folder not specified.", "Error", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error);
+                        throw new Exception("Polipo folder not specified");
+                    }
+                    else if (!IsDirectoryValid(commandLineArgs[i + 1]))
+                    {
+                        System.Windows.Forms.MessageBox.Show("Polipo folder not valid.", "Error", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error);
+                        throw new Exception("Polipo folder not valid");
+                    }
+                    else
+                    {
+                        temppath = commandLineArgs[i + 1];
+                    }
+                }
+            }
             try
             {
                 FileManager.UncompressFile(temppath + "/ss_polipo.exe", Resources.polipo_exe);
@@ -122,6 +147,25 @@ namespace Shadowsocks.Controller
                 return defaultPort;
             }
             throw new Exception("No free port found.");
+        }
+
+        public static bool IsDirectoryValid(string path)
+        {
+            try
+            {
+                if (new DirectoryInfo(path).Exists == true)
+                {
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            catch (Exception e)
+            {
+                return false;
+            }
         }
     }
 }

--- a/shadowsocks-csharp/Controller/PolipoRunner.cs
+++ b/shadowsocks-csharp/Controller/PolipoRunner.cs
@@ -19,7 +19,8 @@ namespace Shadowsocks.Controller
 
         static PolipoRunner()
         {
-            temppath = Path.GetTempPath();
+            // temppath = Path.GetTempPath();
+            temppath = Environment.CurrentDirectory;
             try
             {
                 FileManager.UncompressFile(temppath + "/ss_polipo.exe", Resources.polipo_exe);


### PR DESCRIPTION
This change aims to solve issues when system temp folder is not writable, or executing files from temp folder is blocked.

It added two command line arguments: /SameFolderForPolipo and /PolipoFolder.
If no arguments is used, ss_polipo.exe and polipo.conf are still extracted to temp folder as usual. User should not feel difference.
If /SameFolderForPolipo is used, these two files are extracted to the same folder where Shadowsocks.exe is located.
If /PolipoFolder <path> is used, these two files are extracted to the folder specified here.